### PR TITLE
DMS-19 additional-css-changes

### DIFF
--- a/ckanext/dms/assets/css/colors.css
+++ b/ckanext/dms/assets/css/colors.css
@@ -95,10 +95,6 @@ output {
     color: #f1b752;
 }
 
-.form-control {
-    color: #f1b752;
-}
-
 .input-group-addon {
     color: #f1b752;
 }
@@ -139,4 +135,24 @@ output {
 
 .attribution small {
     color: #fff;
+}
+
+/* other css color overwrites */
+
+a, .form-control {
+    color: #181208;
+}
+
+.nav-tabs>li.active>a, .nav-tabs>li.active>a:hover, .nav-tabs>li.active>a:focus {
+    color: #785b29;
+}
+
+.btn-success{
+    background-image: -webkit-linear-gradient(top, #e59812 0%, #ac720e 100%);
+    background-image: -o-linear-gradient(top, #e59812 0%, #ac720e 100%);
+    background-image: linear-gradient(to bottom, #e59812 0%, #ac720e 100%);
+    filter: progid: DXImageTransform.Microsoft.gradient(startColorstr='#ffe59812', endColorstr='#ffac720e', GradientType=0);
+    filter: progid: DXImageTransform.Microsoft.gradient(enabled=false);
+    background-repeat: repeat-x;
+    border-color: #a36c0d;
 }

--- a/ckanext/dms/assets/css/colors.css
+++ b/ckanext/dms/assets/css/colors.css
@@ -147,12 +147,12 @@ a, .form-control {
     color: #785b29;
 }
 
-.btn-success{
-    background-image: -webkit-linear-gradient(top, #e59812 0%, #ac720e 100%);
-    background-image: -o-linear-gradient(top, #e59812 0%, #ac720e 100%);
-    background-image: linear-gradient(to bottom, #e59812 0%, #ac720e 100%);
-    filter: progid: DXImageTransform.Microsoft.gradient(startColorstr='#ffe59812', endColorstr='#ffac720e', GradientType=0);
+.btn-primary, .btn-success {
+    background-image: -webkit-linear-gradient(top, #125fe5 0%, #0e47ac 100%);
+    background-image: -o-linear-gradient(top, #125fe5 0%, #0e47ac 100%);
+    background-image: linear-gradient(to bottom, #125fe5 0%, #0e47ac 100%);
+    filter: progid: DXImageTransform.Microsoft.gradient(startColorstr='#ff125fe5', endColorstr='#ff0e47ac', GradientType=0);
     filter: progid: DXImageTransform.Microsoft.gradient(enabled=false);
     background-repeat: repeat-x;
-    border-color: #a36c0d;
+    border-color: #0d44a3;
 }

--- a/ckanext/dms/assets/css/colors.css
+++ b/ckanext/dms/assets/css/colors.css
@@ -143,6 +143,10 @@ a, .form-control {
     color: #181208;
 }
 
+a:hover{
+    color: #125fe5;
+}
+
 .nav-tabs>li.active>a, .nav-tabs>li.active>a:hover, .nav-tabs>li.active>a:focus {
     color: #785b29;
 }


### PR DESCRIPTION
# Problem
A lot of the orange colours are too bright when placed above white backgrounds

# Solution
Make text darker to make them easier to read

![image](https://user-images.githubusercontent.com/2634482/132671012-00c00f08-4140-40f9-aa75-588969f35359.png)
