### PR TITLE
DMS-47: Update navbar for mobile/tablet/small devices

### DIFF
--- a/ckanext/dms/assets/css/custom.css
+++ b/ckanext/dms/assets/css/custom.css
@@ -1,55 +1,139 @@
 /* This file overwrites css from the base ckan theme */
 
+
+/* helpers */
+.inline-block {
+	display: inline-block !important;
+}
+
+
+/* remove bar & replace with padding */
+.homepage [role=main] {
+	padding: 0;
+}
+
 .main,
 .hero {
-    background-image: none;
+	padding-top: 20px;
+	background-image: none;
 }
 
-/* .masthead .logo img,
-.site-footer .logo img {
-    background: #ffffff;
-    border-radius: 3px;
-    padding: 3px;
-} */
-
-@media (max-width: 1200px) {
-    .masthead, .site-footer {
-        border-bottom: solid 5px #125fe5;
-    }
+#NavbarBrandingContainer {
+	position: absolute;
+	margin-bottom: -50px;
 }
 
-.masthead .logo img,
-.site-footer .logo img {
-    background-color: white;
-    padding: 3px;
-    border-radius: 3px;
-    box-shadow: rgba(0, 0, 0, 0.08) 0px 4px 12px;
+#NavbarLogo {
+	background-color: white;
+	padding: 3px;
+	border-radius: 3px;
+	box-shadow: rgba(0, 0, 0, 0.08) 0px 4px 12px;
+	height: 130px;
 }
 
-@media (min-width: 1200px) {
-    .masthead .logo img,
-    .site-footer .logo img {
-        max-width: 120px;
-        max-height: none;
-        margin-bottom: -100px;
-    }
+#NavbarHeadingContainer {
+	margin-left: 5px;
+}
+
+#NavbarHeading1,
+#NavbarHeading2 {
+	font-weight: normal;
+}
+
+#NavbarHeading1,
+#NavbarHeading1 :hover{
+	color: white;
+}
+
+#NavbarHeading2 {
+	color: #125fe5;
+}
+
+.fluid-white-bar {
+	background-color: white;
+	height: 80px;
+	border-bottom: solid 5px #125fe5;
 }
 
 
-
-@media (min-width: 992px) {
-    .homepage [role=main] {
-        padding: 0;
-    }
+/* mobile */
+@media only screen and (max-width: 768px) {
+	#NavbarHeadingContainer {
+		margin-top: 12px;
+	}
+	#NavbarLogo {
+		margin-top: -90px;
+	}
+	#NavbarHeading1,
+	#NavbarHeading2 {
+		font-size: 24px;
+		padding: 5px;
+		border-radius: 3px;
+	}
+	#NavbarHeading2 {
+		background-color: white;
+	}
+	.masthead .navbar-collapse {
+		margin-top: 140px;
+	}
 }
 
-.homepage-thumbnail img{
-    max-width: 100%;
-    margin: auto;
-    border-radius: 3px;
+
+/* tablet */
+@media only screen and (min-width: 768px) {
+	#NavbarHeadingContainer {
+		margin-top: 28px;
+	}
+	#NavbarLogo {
+		margin-top: -55px;
+	}
+	#NavbarHeading1,
+	#NavbarHeading2 {
+		font-size: 18px;
+	}
+	.nav>li>a {
+		padding: 5px 7.5px;
+	}
 }
 
-#HomepageBannerImage{
-    width: 100%;
-    border-radius: 3px;
+
+/* medium devices */
+@media only screen and (min-width: 992px) {
+	#NavbarHeadingContainer {
+		margin-top: 33px;
+	}
+	#NavbarLogo {
+		margin-top: -70px;
+	}
+	#NavbarHeading1,
+	#NavbarHeading2 {
+		font-size: 18px;
+	}
+	.nav>li>a {
+		padding: 5px 7.5px;
+	}
+	.masthead .site-search input {
+		margin-top: -5px;
+	}
+}
+
+
+/* desktop */
+@media only screen and (min-width: 1200px) {
+	#NavbarHeadingContainer {
+		margin-top: 30px;
+	}
+	#NavbarLogo {
+		margin-top: -80px;
+	}
+	#NavbarHeading1,
+	#NavbarHeading2 {
+		font-size: 24px;
+	}
+	.nav>li>a {
+		padding: 10px 15px;
+	}
+	.masthead .site-search input {
+		margin-top: 0;
+	}
 }

--- a/ckanext/dms/templates/header.html
+++ b/ckanext/dms/templates/header.html
@@ -1,16 +1,26 @@
 {% ckan_extends %}
 
-{% block header_logo %}  
-  {{ super() }}
-  <a class="no-hover-highlight" href="{{ h.url_for('home.index') }}">
-    <div class="hidden-md hidden-sm hidden-xs">
-      <h1 class="navbar-title">Department of HIV & AIDS</h1>
+{% block header_logo %}
+<div id="NavbarBrandingContainer">
+  <div class="inline-block">
+    <a href="{{ h.url_for('home.index') }}">
+      <img
+        id="NavbarLogo"
+        src="{{ h.url_for_static_or_external(g.site_logo) }}"
+        alt="{{ g.site_title }}"
+        title="{{ g.site_title }}"
+      />
+    </a>
+  </div>
+  <div class="inline-block">
+    <div id="NavbarHeadingContainer">
+      <a href="{{ h.url_for('home.index') }}">
+        <div><h1 id="NavbarHeading1">Department of HIV & AIDS</h1></div>
+        <div><h1 id="NavbarHeading2">Ministry of Health, Malawi</h1></div>
+      </a>
     </div>
-    <div class="hidden-lg navbar-title-md text-center">
-      <div class="first-line">Department of HIV & AIDS</div>
-      <div class="second-line">Ministry of Health, Malawi</div>
-    </div>
-  </a>
+  </div>
+</div>
 {% endblock %}
 
 {% block header_site_navigation_tabs %}
@@ -24,46 +34,5 @@
 
 {% block header_wrapper %}
   {{ super() }}
-  <div class="fluid-white-bar hidden-md hidden-sm hidden-xs">
-    <div class="container">
-        <a class="no-hover-highlight" href="{{ h.url_for('home.index') }}">
-          <h1 class="navbar-title">Ministry of Health, Malawi</h1>
-      </a>
-    </div>
-  </div>
-
-  <style>
-    .fluid-white-bar{
-      background-color: white;
-      height: 80px;
-      color: #125fe5;
-      border-bottom: solid 5px #125fe5;
-    }
-    .navbar-title{
-      font-size: 24px !important;
-      margin: 0 0 0 130px !important;
-      font-weight: normal !important;
-    }
-    .fluid-white-bar .navbar-title{
-      color: #125fe5;
-    }
-    .navbar-title-md{
-      display: inline-block;
-      vertical-align: middle;
-      margin-left: 5px;
-      font-size: 16px;
-      font-weight: bold;
-    }
-    .navbar-title-md .second-line{
-      color: #125fe5;
-      background-color: white;
-      padding: 3px;
-      border-radius: 3px;
-      font-size: 15px;
-    }
-    .no-hover-highlight:hover{
-      text-decoration: none !important;
-    }
-  </style>
-
+  <div class="fluid-white-bar"></div>
 {% endblock %}


### PR DESCRIPTION
- https://fjelltopp.atlassian.net/browse/DMS-47
- Video demo: https://youtu.be/zTZeH3vqeJI

## Desktop
![image](https://user-images.githubusercontent.com/2634482/132700731-a8897a50-4c91-4e0d-ab5b-ef7cffaeba72.png)

## Medium devices
![image](https://user-images.githubusercontent.com/2634482/132700791-20ac3242-5f0c-419e-bc86-eaa332edcaf6.png)

## Tablet
![image](https://user-images.githubusercontent.com/2634482/132700840-2a3c3368-d5b0-4374-85c3-ff458603d405.png)

## Mobile
![image](https://user-images.githubusercontent.com/2634482/132700886-d5e3657e-bfbc-4350-a424-4ecfb170e20b.png)

## Mobile (with navbar open)
Note: there is a kinda useless white bar displayed under the navbar when you open the navs on mobile. This is because we can't know (through css) when the navbar is open, so it's not possible to hide it when not needed. This seems like an ok compromise though. Another option would be to do a bunch of js hacking to figure it out, but this doesn't seem super important to figure out right now.
![image](https://user-images.githubusercontent.com/2634482/132700988-f94a4baf-9d87-4621-ad60-25a3383ea1e0.png)
