### PR TITLE
DMS-19 fix-button-css

### DIFF
--- a/ckanext/dms/assets/css/colors.css
+++ b/ckanext/dms/assets/css/colors.css
@@ -151,12 +151,24 @@ a:hover{
     color: #785b29;
 }
 
-.btn-primary, .btn-success {
+.btn-primary,
+.btn-success {
     background-image: -webkit-linear-gradient(top, #125fe5 0%, #0e47ac 100%);
     background-image: -o-linear-gradient(top, #125fe5 0%, #0e47ac 100%);
     background-image: linear-gradient(to bottom, #125fe5 0%, #0e47ac 100%);
     filter: progid: DXImageTransform.Microsoft.gradient(startColorstr='#ff125fe5', endColorstr='#ff0e47ac', GradientType=0);
     filter: progid: DXImageTransform.Microsoft.gradient(enabled=false);
     background-repeat: repeat-x;
+    border-color: #0d44a3;
+}
+
+.btn-primary:hover, .btn-primary:focus,
+.btn-success:hover, .btn-success:focus {
+    background-color: #125fe5;
+}
+
+.btn-primary:active, .btn-primary.active,
+.btn-success:active, .btn-success.active {
+    background-color: #125fe5;
     border-color: #0d44a3;
 }


### PR DESCRIPTION
# Before
When a `btn-primary` or `btn-success` button is active or focused, it looks bad:

active
![image](https://user-images.githubusercontent.com/2634482/133251015-2c8e424a-f7ef-42ce-822a-dd9be03d131e.png)

focus
![image](https://user-images.githubusercontent.com/2634482/133249253-c7e473e9-edf9-4a77-b99c-e5f6bd36de7d.png)


# After


active
![image](https://user-images.githubusercontent.com/2634482/133250480-bfc2b3e5-6c76-452c-bf4c-472506360237.png)

focus
![image](https://user-images.githubusercontent.com/2634482/133248751-2287a776-bd2c-4737-824b-010518da23d7.png)

