### PR TITLE
DMS-109 Remove group from dataset

### DIFF
--- a/ckanext/dms/assets/css/dms.css
+++ b/ckanext/dms/assets/css/dms.css
@@ -323,6 +323,7 @@ p.small {
     border-radius: 4px;
     margin-bottom: 24px;
     padding:  20px;
+    height:  110px;
 }
 
 .category-box .group-thumbnail {
@@ -353,6 +354,16 @@ p.small {
     color: #212121;
     overflow:  hidden;
     height:  50px;
+}
+
+.category-box .btn-delete {
+    background: transparent;
+    color: #990005;
+    font-size: 20px;
+    padding: 20px;
+    position: absolute;
+    bottom: 10px;
+    right: 10px;
 }
 
 .dataset-resources li{
@@ -681,12 +692,4 @@ a.tag:hover  {
 	background-color: #990005;
 }
 
-.category-box .btn-delete {
-    background: transparent;
-    color: #990005;
-    font-size: 20px;
-    padding: 20px;
-    position: absolute;
-    bottom: 10px;
-    right: 10px;
-}
+

--- a/ckanext/dms/assets/css/dms.css
+++ b/ckanext/dms/assets/css/dms.css
@@ -680,3 +680,13 @@ a.tag:hover  {
 .recently-updated .view-all-btn{
 	background-color: #990005;
 }
+
+.category-box .btn-delete {
+    background: transparent;
+    color: #990005;
+    font-size: 20px;
+    padding: 20px;
+    position: absolute;
+    bottom: 10px;
+    right: 10px;
+}

--- a/ckanext/dms/templates/group/snippets/group_item.html
+++ b/ckanext/dms/templates/group/snippets/group_item.html
@@ -11,9 +11,6 @@
                 <div class="title">
                     <a href="{{ url }}">{{ group.title }}</a>
                 </div>
-                {% if group.description %}
-                    <div class="desc">{{ h.markdown_extract(group.description, extract_length=80) }}</div>
-                {% endif %}
                 {% if group.package_count %}
                   <div class="desc">{{ ungettext('{num} Dataset', '{num} Datasets', group.package_count).format(num=group.package_count) }}</div>
                 {% endif %}

--- a/ckanext/dms/templates/group/snippets/group_item.html
+++ b/ckanext/dms/templates/group/snippets/group_item.html
@@ -1,0 +1,32 @@
+{% ckan_extends %}
+
+{% set type = group.type or 'group' %}
+{% set url = h.url_for(type ~ '.read', id=group.name) %}
+{% block item %}
+
+    <div class="col-lg-4 col-md-6 col-xs-12">
+        <div class="category-box">
+            <img src="{{ group.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" alt="{{ group.name }}" class="media-image group-thumbnail">
+            <div class="group-text">
+                <div class="title">
+                    <a href="{{ url }}">{{ group.title }}</a>
+                </div>
+                {% if group.description %}
+                    <div class="desc">{{ h.markdown_extract(group.description, extract_length=80) }}</div>
+                {% endif %}
+                {% if group.package_count %}
+                  <div class="desc">{{ ungettext('{num} Dataset', '{num} Datasets', group.package_count).format(num=group.package_count) }}</div>
+                {% endif %}
+                {% if group.user_member %}
+                    <button name="group_remove.{{ group.id }}"
+                            type="submit"
+                            class="btn btn-delete btn-sm media-edit"
+                            title="{{_('Remove dataset from this group')}}"/>
+                      <i class="fa fa-remove"> </i>
+                    </button>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+
+{% endblock %}

--- a/ckanext/dms/templates/group/snippets/group_list.html
+++ b/ckanext/dms/templates/group/snippets/group_list.html
@@ -4,17 +4,7 @@
     {% set groups = groups %}
     <div class="row">
         {% for group in groups %}
-        <div class="col-lg-4 col-md-6 col-xs-12">
-            <div class="category-box">
-                <img src="{{ group.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" alt="{{ group.name }}" class="media-image group-thumbnail">
-                <div class="group-text">
-                    <div class="title">
-                        <a href="{{ h.url_for('/group/' + group.name) }}">{{ group.title }}</a>
-                    </div>
-                    <div class="desc">{{ h.markdown_extract(group.description, extract_length=70) }}</div>
-                </div>
-            </div>
-        </div>
+            {% snippet "group/snippets/group_item.html", group=group, position=loop.index %}
         {% endfor %}
     </div>
 {% endblock %}

--- a/ckanext/dms/templates/package/group_list.html
+++ b/ckanext/dms/templates/package/group_list.html
@@ -1,4 +1,4 @@
-{% extends "package/read_base.html" %}
+{% ckan_extends %}
 {% import 'macros/form.html' as form %}
 
 {% block primary_content_inner %}


### PR DESCRIPTION
This PR improves the appearance of category boxes and adds a small remove button if you are an editor viewing the categories for a specific dataset. 

This remove button did exist, but was lost in the transition to the new UI. 

I have replaced it with a little cross symbol instead of the word remove. I believe it looks better this way.  There is still a tool tip that appears explaining the behaviour of the button. 

The PR is entirely Jinja2 and CSS

![image](https://user-images.githubusercontent.com/8988344/199481833-3c842327-329c-455c-a65a-eff1caf52021.png)
